### PR TITLE
Add masking support when `plan` has an attribute being removed

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ var lineTests = []struct {
 	{"random_id.some_id", " id:               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" => <computed> (forces new resource)",
 		" id:               \"**************************************************************************************\" => <computed> (forces new resource)",
 		"0.11"},
-	// tf 0.12 ------------------------------------
+	//tf 0.12 ------------------------------------
 	{"random_id.some_id", "not_secret", "not_secret", "0.12"},
 	{"random_id.some_id", "      ~ result           = \"pkwemfpwmfwf\" -> (known after apply) ",
 		"      ~ result           = \"************\" -> (known after apply) ", "0.12"},
@@ -44,6 +44,12 @@ var lineTests = []struct {
 		"0.12"},
 	{"random_id.some_id", " ~ id =               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" -> (known after apply)",
 		" ~ id =               \"**************************************************************************************\" -> (known after apply)",
+		"0.12"},
+	{"random_id.some_id", " - id =               \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" -> null",
+		" - id =               \"**************************************************************************************\" -> null",
+		"0.12"},
+	{"random_id.some_id", " - \"id\" = \"VIxvs2TloohI2XtAsHyu68wQvFQQCTOGgsglqC7zKjsnOmUMIMrZ1y5J6ieOIzl-YXiS1_XmVc8J8gb9fIcwIA\" -> null",
+		" - \"id\" = \"**************************************************************************************\" -> null",
 		"0.12"},
 	{"", "random_string.some_password: Creation complete after 0s [id=5s80SMs@JJpA8e/h]",
 		"random_string.some_password: Creation complete after 0s [id=****************]",


### PR DESCRIPTION
`terraform plan`:
```hcl
  ~ resource "heroku_app" "default" {
      ~ config_vars           = {
          - "FOOBAR" = "***" -> null
            # (1 unchanged element hidden)
        }
        id                    = "tftest9999"
      ~ name                  = "tftest9999" -> "tftest99991"
        # (11 unchanged attributes hidden)
    }
```

`terraform destroy`:
```
Terraform will perform the following actions:

  # heroku_app.default will be destroyed
  - resource "heroku_app" "default" {
      - acm                   = false -> null
      - all_config_vars       = (sensitive value)
      - buildpacks            = [] -> null
      - config_vars           = {
          - "DAVID"  = "JI"
          - "FOOBAR" = "***"
        } -> null
      - git_url               = "https://git.heroku.com/tftest9999.git" -> null
      - heroku_hostname       = "tftest9999.herokuapp.com" -> null
      - id                    = "**********" -> null
      - internal_routing      = false -> null
      - name                  = "tftest9999" -> null
      - region                = "us" -> null
      - sensitive_config_vars = (sensitive value)
      - stack                 = "heroku-20" -> null
      - uuid                  = "e574b750-7e33-441c-b375-d01f4e1e60c6" -> null
      - web_url               = "https://tftest9999.herokuapp.com/" -> null
    }
```

Tests passed.